### PR TITLE
fix: return raw data from db query functions

### DIFF
--- a/apps/wca-certificates/db/queries.ts
+++ b/apps/wca-certificates/db/queries.ts
@@ -106,7 +106,7 @@ export async function getTeams(): Promise<Team[]> {
 
     const data = await res.json();
 
-    return data.teams;
+    return data;
   } catch (error) {
     console.error("Error fetching teams:", error);
     return [];
@@ -126,7 +126,7 @@ export async function getStates(): Promise<State[]> {
 
     const data = await res.json();
 
-    return data.states;
+    return data;
   } catch (error) {
     console.error("Error fetching states:", error);
     return [];
@@ -149,7 +149,7 @@ export async function getCompetitorStates(competitionId: string): Promise<
 
     const data = await res.json();
 
-    return data.competitors;
+    return data;
   } catch (error) {
     console.error("Error fetching competitors:", error);
     return [];


### PR DESCRIPTION
Adjust getTeams, getStates, and getCompetitorStates to return the parsed JSON response directly instead of accessing nested properties (data.teams, data.states, data.competitors). This matches an API change where the endpoints now return the arrays as the top-level response. Callers expecting the previous nested shape should be updated accordingly; error logging and fallback behavior are unchanged.