### PR TITLE
fix: WCA certificates: UI, save/load, and cleanup

### DIFF
--- a/apps/wca-certificates/app/(root)/certificates/[competitionId]/page.tsx
+++ b/apps/wca-certificates/app/(root)/certificates/[competitionId]/page.tsx
@@ -23,11 +23,11 @@ export default async function Page({
   }
 
   const resultsPostedAt = new Date(competition.end_date);
-  const isResultsOlderThan3Months = resultsPostedAt
-    ? isBefore(resultsPostedAt, subMonths(new Date(), 3))
+  const isResultsOlderThanAMonth = resultsPostedAt
+    ? isBefore(resultsPostedAt, subMonths(new Date(), 1))
     : false;
 
-  if (isResultsOlderThan3Months) {
+  if (isResultsOlderThanAMonth) {
     return (
       <div className="relative border-2 border-amber-200 dark:border-amber-900/50 rounded-xl p-8 sm:p-10 shadow-lg bg-linear-to-br from-amber-50/50 to-orange-50/30 dark:from-amber-950/20 dark:to-orange-950/10 backdrop-blur-sm">
         <div className="absolute inset-0 bg-grid-amber-900/[0.02] dark:bg-grid-amber-100/[0.02] rounded-xl" />
@@ -44,7 +44,7 @@ export default async function Page({
           <div className="space-y-5 text-base">
             <div className="rounded-lg bg-white/60 dark:bg-gray-900/40 p-5 border border-amber-100 dark:border-amber-900/30">
               <p className="leading-relaxed text-gray-700 dark:text-gray-300">
-                Los resultados de esta competencia tienen más de 3 meses, por lo
+                Los resultados de esta competencia tienen más de 1 mes, por lo
                 que no están disponibles para generar certificados.
               </p>
             </div>

--- a/apps/wca-certificates/app/unauthorized.tsx
+++ b/apps/wca-certificates/app/unauthorized.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { Button } from "@workspace/ui/components/button";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from "@workspace/ui/components/card";
+import { Lock, RefreshCw } from "lucide-react";
+import { SignIn } from "@/components/auth-components";
+
+export default function CustomUnauthorized(): React.JSX.Element {
+  return (
+    <main className="grow flex items-center justify-center">
+      <div className="container max-w-3xl px-4 py-16">
+        <Card className="border-red-200 dark:border-red-600 shadow-lg">
+          <CardHeader className="text-center pb-2">
+            <div className="flex justify-center mb-6">
+              <div className="relative w-32 h-32">
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <div className="grid grid-cols-3 gap-1 rotate-12 scale-110">
+                    {[...Array(9)].map((_, i) => (
+                      <div
+                        key={i}
+                        className={`w-8 h-8 rounded-md ${
+                          [0, 2, 6, 8].includes(i)
+                            ? "bg-red-400 dark:bg-red-600"
+                            : [1, 3, 5, 7].includes(i)
+                              ? "bg-red-300 dark:bg-red-500"
+                              : "bg-white border-2 border-gray-300 dark:border-gray-600"
+                        }`}
+                      />
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className="flex justify-center mb-4">
+              <Lock className="h-12 w-12 text-destructive" />
+            </div>
+            <CardTitle className="text-2xl md:text-3xl font-bold text-red-700 dark:text-red-400">
+              Tu sesión terminó
+            </CardTitle>
+            <CardDescription className="text-lg mt-2">
+              Vuelve a iniciar sesión con tu cuenta de la World Cube Association
+              para continuar.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="text-center space-y-4">
+            <p className="text-muted-foreground">
+              Tu sesión pudo expirar o necesitas autenticarte de nuevo para ver
+              esta sección.
+            </p>
+
+            <div className="bg-amber-50 border border-amber-200 dark:border-amber-600 dark:bg-amber-900 rounded-lg p-4 mt-6 text-left">
+              <h3 className="font-semibold text-amber-800 dark:text-white mb-2">
+                ¿Qué hago ahora?
+              </h3>
+              <ul className="list-disc list-inside text-sm text-amber-700 dark:text-white space-y-1">
+                <li>Inicia sesión otra vez con tu cuenta WCA</li>
+                <li>Verifica que estés usando la cuenta correcta</li>
+                <li>Si el problema continúa, vuelve a cargar la página</li>
+              </ul>
+            </div>
+          </CardContent>
+          <CardFooter className="flex flex-col gap-3 justify-center pt-2">
+            <SignIn />
+            <Button asChild variant="outline" className="w-full sm:w-auto">
+              <a href="/sign-in">
+                <RefreshCw className="mr-2 h-5 w-5" />
+                Ir a la página de acceso
+              </a>
+            </Button>
+          </CardFooter>
+        </Card>
+      </div>
+    </main>
+  );
+}

--- a/apps/wca-certificates/components/competition-card.tsx
+++ b/apps/wca-certificates/components/competition-card.tsx
@@ -52,11 +52,11 @@ export function CompetitionCard({
   const resultsPostedAt = competition.results_posted_at
     ? new Date(competition.results_posted_at)
     : null;
-  const isResultsOlderThan3Months = resultsPostedAt
-    ? isBefore(resultsPostedAt, subMonths(new Date(), 3))
+  const isResultsOlderThanAMonth = resultsPostedAt
+    ? isBefore(resultsPostedAt, subMonths(new Date(), 1))
     : false;
   const isNotAvailable =
-    competition.announced_at === null || isResultsOlderThan3Months;
+    competition.announced_at === null || isResultsOlderThanAMonth;
 
   return (
     <Card className="group overflow-hidden transition-all duration-300 hover:shadow-lg hover:scale-[1.02] hover:border-primary/50">

--- a/apps/wca-certificates/components/editor/dialog-document-settings.tsx
+++ b/apps/wca-certificates/components/editor/dialog-document-settings.tsx
@@ -33,6 +33,7 @@ interface DialogDocumentSettingsProps {
   setPageSize: (value: PageSize) => void;
   pageMargins: Margins;
   setPageMargins: (value: Margins) => void;
+  certificateVariant: "participation" | "podium";
 }
 
 export function DialogDocumentSettings({
@@ -42,6 +43,7 @@ export function DialogDocumentSettings({
   setPageSize,
   pageMargins,
   setPageMargins,
+  certificateVariant,
 }: DialogDocumentSettingsProps): React.JSX.Element {
   const [open, setOpen] = useState(false);
   const [tempPageOrientation, setTempPageOrientation] =
@@ -59,6 +61,14 @@ export function DialogDocumentSettings({
     setPageOrientation(tempPageOrientation);
     setPageSize(tempPageSize);
     setPageMargins(tempPageMargins);
+  };
+
+  const handleReset = () => {
+    setTempPageOrientation(
+      certificateVariant === "participation" ? "portrait" : "landscape",
+    );
+    setTempPageSize("LETTER");
+    setTempPageMargins([40, 60, 40, 60]);
   };
 
   return (
@@ -230,6 +240,9 @@ export function DialogDocumentSettings({
           </div>
         </div>
         <DialogFooter>
+          <Button onClick={handleReset} variant="outline">
+            Restablecer
+          </Button>
           <Button onClick={() => setOpen(false)} variant="secondary">
             Cancelar
           </Button>

--- a/apps/wca-certificates/components/editor/tiptap.tsx
+++ b/apps/wca-certificates/components/editor/tiptap.tsx
@@ -77,6 +77,30 @@ interface TiptapProps {
   background: string | undefined;
 }
 
+interface SavedDocumentFile {
+  content: JSONContent;
+  pageConfig: {
+    pageSize: PageSize;
+    pageOrientation: PageOrientation;
+    pageMargins: Margins;
+  };
+}
+
+const isSavedDocumentFile = (value: unknown): value is SavedDocumentFile => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const pageConfig = candidate.pageConfig;
+
+  if (!pageConfig || typeof pageConfig !== "object") {
+    return false;
+  }
+
+  return "content" in candidate;
+};
+
 export default function Tiptap({
   content,
   pdfDisabled,
@@ -188,7 +212,15 @@ export default function Tiptap({
 
   const saveContent = () => {
     const content = editor.getJSON();
-    const jsonString = JSON.stringify(content);
+    const documentFile: SavedDocumentFile = {
+      content,
+      pageConfig: {
+        pageSize,
+        pageOrientation,
+        pageMargins,
+      },
+    };
+    const jsonString = JSON.stringify(documentFile);
     const blob = new Blob([jsonString], { type: "application/json" });
     const url = URL.createObjectURL(blob);
 
@@ -214,7 +246,18 @@ export default function Tiptap({
       }
 
       const jsonString = await file.text();
-      const content = JSON.parse(jsonString) as JSONContent;
+      const parsed = JSON.parse(jsonString) as unknown;
+
+      if (isSavedDocumentFile(parsed)) {
+        setPageSize(parsed.pageConfig.pageSize);
+        setPageOrientation(parsed.pageConfig.pageOrientation);
+        setPageMargins(parsed.pageConfig.pageMargins);
+        editor.commands.setContent(parsed.content);
+        handleChange(parsed.content);
+        return;
+      }
+
+      const content = parsed as JSONContent;
       editor.commands.setContent(content);
       handleChange(content);
     };
@@ -264,6 +307,7 @@ export default function Tiptap({
               setPageMargins={setPageMargins}
               setPageOrientation={setPageOrientation}
               setPageSize={setPageSize}
+              certificateVariant={variant}
             />
           </MenubarContent>
         </MenubarMenu>

--- a/apps/wca-certificates/next-env.d.ts
+++ b/apps/wca-certificates/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/app/(root)/persons/[id]/_lib/queries.ts
+++ b/apps/web/app/(root)/persons/[id]/_lib/queries.ts
@@ -26,30 +26,13 @@ export async function getWcaPersonData(
   cacheTag(`wca-person-data-${wcaId}`);
 
   try {
-    // Log that we're about to call the external WCA API (passive detection)
-    try {
-      console.log("wca-fetch", { wcaId, at: new Date().toISOString() });
-    } catch (_) {}
-
     const response = await fetch(
       `https://www.worldcubeassociation.org/api/v0/persons/${wcaId}`,
-      {
-        next: {
-          revalidate: 86400,
-          tags: ["wca-person", `wca-person-${wcaId}`],
-        },
-      },
     );
 
-    try {
-      console.log("wca-fetch-result", {
-        wcaId,
-        status: response.status,
-        cache: response.headers.get("x-vercel-cache") ?? null,
-      });
-    } catch (_) {}
-
-    if (!response.ok) return null;
+    if (!response.ok) {
+      return null;
+    }
 
     return response.json();
   } catch {

--- a/apps/web/app/(root)/persons/[id]/page.tsx
+++ b/apps/web/app/(root)/persons/[id]/page.tsx
@@ -56,36 +56,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-async function PersonPageContent({
-  id,
-  requestHeaders,
-}: {
-  id: string;
-  requestHeaders?: {
-    ua?: string | null;
-    ip?: string | null;
-    referer?: string | null;
-    prerender?: string | null;
-  };
-}) {
+async function PersonPageContent({ id }: { id: string }) {
   "use cache";
   cacheLife("days");
   cacheTag(`person-page-${id}`);
-  // Passive header logging for bot detection — remove after investigation
-  try {
-    console.log("persons-invoke", {
-      id,
-      ua: requestHeaders?.ua ?? null,
-      ip: requestHeaders?.ip ?? null,
-      referer: requestHeaders?.referer ?? null,
-      prerender: requestHeaders?.prerender ?? null,
-    });
-  } catch (e) {
-    // best-effort logging, don't throw
-  }
 
-  // Fetch events first — cached with cacheLife("max"), effectively free after first call.
-  // This unblocks getMembershipData so everything else can run in a single Promise.all.
   const events = await getEvents();
 
   const [
@@ -490,14 +465,6 @@ export default async function Page({
   params: Promise<{ id: string }>;
 }) {
   const id = (await params).id;
-  // Collect headers outside of cached scope and pass into the cached component
-  const h = await headers();
-  const requestHeaders = {
-    ua: h.get("user-agent"),
-    ip: h.get("x-forwarded-for"),
-    referer: h.get("referer"),
-    prerender: h.get("x-prerender") ?? null,
-  };
 
-  return <PersonPageContent id={id} requestHeaders={requestHeaders} />;
+  return <PersonPageContent id={id} />;
 }

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Multiple updates across the WCA certificates and web apps:

- Change results availability threshold from 3 months to 1 month in certificates page and competition card so recent results are considered unavailable sooner.
- Add a custom unauthorized page (app/unauthorized.tsx) with sign-in UI and guidance for expired sessions.
- Editor improvements: DialogDocumentSettings gains a certificateVariant prop and a "Restablecer" (reset) button that restores page orientation/size/margins based on variant defaults.
- Tiptap editor: persist pageConfig (pageSize, pageOrientation, pageMargins) alongside document content when saving; detect and restore saved pageConfig when loading; introduce SavedDocumentFile type and pass certificateVariant into the dialog.
- Remove passive console logging and next fetch options from web person queries; simplify fetch error handling in getWcaPersonData and reduce noisy header logging in PersonPageContent (no longer passing headers into the cached component).
- Fix next-env.d.ts imports in both apps to reference .next/types/routes.d.ts instead of .next/dev/types/routes.d.ts.

These changes improve UX for certificate generation, add persistence for document settings, and remove noisy telemetry/logging code.