### PR TITLE
feat: remove person sitemap

### DIFF
--- a/apps/wca-certificates/next-env.d.ts
+++ b/apps/wca-certificates/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,9 +1,4 @@
-import {
-  getCompetitions,
-  getEvents,
-  getPersons,
-  getStates,
-} from "@/db/queries";
+import { getCompetitions, getEvents, getStates } from "@/db/queries";
 import type { MetadataRoute } from "next";
 import { cacheLife, cacheTag } from "next/cache";
 
@@ -14,7 +9,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   const states = await getStates();
   const events = await getEvents();
-  const persons = await getPersons();
   const competitions = await getCompetitions();
 
   const teamUrls = states.map((state) => {
@@ -101,14 +95,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       url: `https://www.cubingmexico.net/rankings/${event.id}/average/results`,
       changeFrequency: "weekly" as const,
       priority: 0.6,
-    };
-  });
-
-  const personUrls = persons.map((person) => {
-    return {
-      url: `https://www.cubingmexico.net/persons/${person.wcaId}`,
-      changeFrequency: "monthly" as const,
-      priority: 0.5,
     };
   });
 
@@ -217,7 +203,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: "weekly",
       priority: 0.5,
     },
-    ...personUrls,
     {
       url: "https://www.cubingmexico.net/organizers",
       changeFrequency: "weekly",

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
In apps/web/app/sitemap.ts remove the unused getPersons import and the personUrls generation/inclusion to avoid an extra DB query and remove /persons entries from the sitemap; also consolidate imports.