### PR TITLE
feat: add staff competitions to person pages

### DIFF
--- a/apps/wca-certificates/components/badge-manager.tsx
+++ b/apps/wca-certificates/components/badge-manager.tsx
@@ -147,7 +147,8 @@ export function BadgeManager({
 
     for (const p of filteredPersons) {
       // prioritize delegate over organizer
-      const isDelegate = p.roles?.includes("delegate") || p.roles?.includes("trainee-delegate");
+      const isDelegate =
+        p.roles?.includes("delegate") || p.roles?.includes("trainee-delegate");
       const isOrganizer = p.roles?.includes("organizer");
       const isVolunteer = p.roles?.find((r) => r.startsWith("staff-"));
 

--- a/apps/wca-certificates/lib/auth.ts
+++ b/apps/wca-certificates/lib/auth.ts
@@ -97,9 +97,10 @@ export const auth = betterAuth({
               id: userId,
               name: data.me.name,
               email: `${userId.toLowerCase()}@wca.org`,
-              image: (data.me.avatar.url
-                ? data.me.avatar.thumb_url
-                : data.me.avatar.pending_url) ?? undefined,
+              image:
+                (data.me.avatar.url
+                  ? data.me.avatar.thumb_url
+                  : data.me.avatar.pending_url) ?? undefined,
               emailVerified: true,
             };
           },

--- a/apps/web/app/(root)/persons/[id]/_components/staff-competitions-tab.tsx
+++ b/apps/web/app/(root)/persons/[id]/_components/staff-competitions-tab.tsx
@@ -1,0 +1,115 @@
+import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@workspace/ui/components/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@workspace/ui/components/table";
+import { Badge } from "@workspace/ui/components/badge";
+import { formatDate } from "@/lib/utils";
+import type { PersonStaffCompetition } from "../_lib/queries";
+
+type PersonStaffCompetitionsTabProps = {
+  organized: PersonStaffCompetition[];
+  delegated: PersonStaffCompetition[];
+};
+
+function StaffCompetitionTable({
+  competitions,
+  emptyMessage,
+}: {
+  competitions: PersonStaffCompetition[];
+  emptyMessage: string;
+}) {
+  if (competitions.length === 0) {
+    return <p className="text-sm text-muted-foreground">{emptyMessage}</p>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Fecha</TableHead>
+            <TableHead>Nombre</TableHead>
+            <TableHead>Estado</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {competitions.map((competition) => (
+            <TableRow key={competition.id}>
+              <TableCell className="whitespace-nowrap">
+                {formatDate(competition.startDate, competition.endDate)}
+              </TableCell>
+              <TableCell>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Link
+                    className="font-medium hover:underline"
+                    href={`/competitions/${competition.id}`}
+                  >
+                    {competition.name}
+                  </Link>
+                  {competition.cancelled && (
+                    <Badge variant="secondary">Cancelada</Badge>
+                  )}
+                </div>
+              </TableCell>
+              <TableCell>
+                {competition.stateName ?? (
+                  <span className="text-muted-foreground font-thin">N/A</span>
+                )}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+export function PersonStaffCompetitionsTab({
+  organized,
+  delegated,
+}: PersonStaffCompetitionsTabProps) {
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            Organizadas
+            <Badge variant="secondary">{organized.length}</Badge>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <StaffCompetitionTable
+            competitions={organized}
+            emptyMessage="Esta persona no ha organizado competencias."
+          />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            Delegadas
+            <Badge variant="secondary">{delegated.length}</Badge>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <StaffCompetitionTable
+            competitions={delegated}
+            emptyMessage="Esta persona no ha delegado competencias."
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/app/(root)/persons/[id]/_lib/queries.ts
+++ b/apps/web/app/(root)/persons/[id]/_lib/queries.ts
@@ -4,6 +4,7 @@ import { roundRank } from "@/lib/utils";
 import {
   championship,
   competition,
+  competitionDelegate,
   competitionOrganizer,
   delegate,
   organizer,
@@ -39,6 +40,16 @@ export interface PersonCompetitionLocation {
   latitude: number | null;
   longitude: number | null;
 }
+
+export type PersonStaffCompetition = {
+  id: string;
+  name: string;
+  startDate: Date;
+  endDate: Date;
+  stateName: string | null;
+  cityName: string;
+  cancelled: boolean;
+};
 
 type PersonCompetitionResultRow = {
   resultId: string;
@@ -361,6 +372,81 @@ export async function getOrganizerStatus(
   }
 }
 
+const staffCompetitionSelect = {
+  id: competition.id,
+  name: competition.name,
+  startDate: competition.startDate,
+  endDate: competition.endDate,
+  stateName: state.name,
+  cityName: competition.cityName,
+  cancelled: competition.cancelled,
+};
+
+export async function getPersonStaffCompetitions(wcaId: string): Promise<{
+  organized: PersonStaffCompetition[];
+  delegated: PersonStaffCompetition[];
+}> {
+  "use cache";
+  cacheLife("days");
+  cacheTag(`person-staff-competitions-${wcaId}`);
+
+  try {
+    const [organized, delegated] = await Promise.all([
+      db
+        .select(staffCompetitionSelect)
+        .from(organizer)
+        .innerJoin(
+          competitionOrganizer,
+          eq(competitionOrganizer.organizerId, organizer.id),
+        )
+        .innerJoin(
+          competition,
+          eq(competitionOrganizer.competitionId, competition.id),
+        )
+        .leftJoin(state, eq(competition.stateId, state.id))
+        .where(eq(organizer.personId, wcaId))
+        .groupBy(
+          competition.id,
+          competition.name,
+          competition.startDate,
+          competition.endDate,
+          state.name,
+          competition.cityName,
+          competition.cancelled,
+        )
+        .orderBy(desc(competition.startDate)),
+      db
+        .select(staffCompetitionSelect)
+        .from(delegate)
+        .innerJoin(
+          competitionDelegate,
+          eq(competitionDelegate.delegateId, delegate.id),
+        )
+        .innerJoin(
+          competition,
+          eq(competitionDelegate.competitionId, competition.id),
+        )
+        .leftJoin(state, eq(competition.stateId, state.id))
+        .where(eq(delegate.personId, wcaId))
+        .groupBy(
+          competition.id,
+          competition.name,
+          competition.startDate,
+          competition.endDate,
+          state.name,
+          competition.cityName,
+          competition.cancelled,
+        )
+        .orderBy(desc(competition.startDate)),
+    ]);
+
+    return { organized, delegated };
+  } catch (err) {
+    console.error(err);
+    return { organized: [], delegated: [] };
+  }
+}
+
 export async function getPersonCompetitionEventOptions(wcaId: string) {
   "use cache";
   cacheLife("days");
@@ -575,17 +661,12 @@ export async function getPersonDataFromWCA(
   wcaId: string,
 ): Promise<WcaPersonResponse | null> {
   "use cache";
-  cacheLife("days");
+  cacheLife("weeks");
   cacheTag(`person-data-wca-${wcaId}`);
 
   try {
     const response = await fetch(
       `https://www.worldcubeassociation.org/api/v0/persons/${wcaId}`,
-      {
-        next: {
-          revalidate: 60 * 60 * 24, // 1 day
-        },
-      },
     );
 
     if (!response.ok) {

--- a/apps/web/app/(root)/persons/[id]/page.tsx
+++ b/apps/web/app/(root)/persons/[id]/page.tsx
@@ -35,6 +35,7 @@ import {
 } from "@workspace/ui/components/tabs";
 import { MapContainer } from "./_components/map-container";
 import { PersonResultsTab } from "./_components/results-tab";
+import { PersonStaffCompetitionsTab } from "./_components/staff-competitions-tab";
 import {
   getPersonData,
   getOrganizerStatus,
@@ -43,6 +44,7 @@ import {
   getPersonCompetitionLocations,
   getPersonCompetitionResults,
   getPersonDataFromWCA,
+  getPersonStaffCompetitions,
 } from "./_lib/queries";
 import type { PersonalRecordWithStateRank } from "./_lib/queries";
 import { notFound } from "next/navigation";
@@ -111,6 +113,7 @@ async function PersonPageContent({
     eventOptions,
     locations,
     statesData,
+    staffCompetitions,
   ] = await Promise.all([
     getPersonData(id),
     getOrganizerStatus(id),
@@ -121,6 +124,7 @@ async function PersonPageContent({
     getPersonCompetitionEventOptions(id),
     getPersonCompetitionLocations(id),
     getStatesGeoJSON(),
+    getPersonStaffCompetitions(id),
   ]);
 
   if (!personData) {
@@ -129,6 +133,8 @@ async function PersonPageContent({
 
   const { person, competitionCount, personalRecords, medals, regionalRecords } =
     personData;
+  const { organized, delegated } = staffCompetitions;
+  const hasStaffCompetitions = organized.length > 0 || delegated.length > 0;
   const isOrganizer = organizerStatus !== null;
 
   const stateIds = locations
@@ -468,9 +474,17 @@ async function PersonPageContent({
         </div>
       </div>
       <Tabs defaultValue="results-by-event" className="mt-6">
-        <TabsList className="grid w-full grid-cols-2">
+        <TabsList
+          className={cn(
+            "grid w-full",
+            hasStaffCompetitions ? "grid-cols-3" : "grid-cols-2",
+          )}
+        >
           <TabsTrigger value="results-by-event">Resultados</TabsTrigger>
           <TabsTrigger value="map">Mapa</TabsTrigger>
+          {hasStaffCompetitions && (
+            <TabsTrigger value="staff-competitions">Organización</TabsTrigger>
+          )}
         </TabsList>
 
         <TabsContent value="results-by-event" className="mt-6">
@@ -491,6 +505,15 @@ async function PersonPageContent({
             statesData={filteredStatesData}
           />
         </TabsContent>
+
+        {hasStaffCompetitions && (
+          <TabsContent value="staff-competitions" className="mt-6">
+            <PersonStaffCompetitionsTab
+              organized={organized}
+              delegated={delegated}
+            />
+          </TabsContent>
+        )}
       </Tabs>
     </>
   );


### PR DESCRIPTION
Show organized and delegated competitions on person profiles in a new Organization tab, and fetch the needed data from cached queries. Also adjust WCA profile data caching and keep a couple of auth/badge formatting tweaks.