### PR TITLE
fix: lazy-load person tabs and cache results views

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ pnpm services:up
 
 This brings up:
 
-| Service   | What it does                                      | URL / port        |
-|-----------|---------------------------------------------------|-------------------|
-| `db`      | PostgreSQL 16                                     | `localhost:5432`  |
-| `migrator`| Drizzle migrate + seed (Mexican states), then exits | —               |
-| `backend` | Flask API                                         | `http://localhost:8080` |
+| Service    | What it does                                        | URL / port              |
+| ---------- | --------------------------------------------------- | ----------------------- |
+| `db`       | PostgreSQL 16                                       | `localhost:5432`        |
+| `migrator` | Drizzle migrate + seed (Mexican states), then exits | —                       |
+| `backend`  | Flask API                                           | `http://localhost:8080` |
 
 Check status and logs:
 
@@ -145,21 +145,21 @@ pnpm services:up
 
 ## Scripts
 
-| Command | Description |
-|---------|-------------|
-| `pnpm install` | Install all workspace dependencies |
-| `pnpm services:up` | Start db + migrator + backend via Docker Compose |
-| `pnpm db:up` | Start Postgres only |
-| `pnpm db:down` | Stop Compose services |
-| `pnpm dev:web` | Next.js web app (Turbo) |
-| `pnpm dev:wca-certificates` | Certificates app (Turbo) |
-| `pnpm dev` | All apps in development mode |
-| `pnpm build` | Build all apps and packages |
-| `pnpm lint` | Lint all apps and packages |
-| `pnpm format` | Format with Prettier |
-| `pnpm --filter web db:migrate` | Apply Drizzle migrations |
-| `pnpm --filter web db:seed` | Seed Mexican states |
-| `pnpm --filter web db:studio` | Open Drizzle Studio |
+| Command                        | Description                                      |
+| ------------------------------ | ------------------------------------------------ |
+| `pnpm install`                 | Install all workspace dependencies               |
+| `pnpm services:up`             | Start db + migrator + backend via Docker Compose |
+| `pnpm db:up`                   | Start Postgres only                              |
+| `pnpm db:down`                 | Stop Compose services                            |
+| `pnpm dev:web`                 | Next.js web app (Turbo)                          |
+| `pnpm dev:wca-certificates`    | Certificates app (Turbo)                         |
+| `pnpm dev`                     | All apps in development mode                     |
+| `pnpm build`                   | Build all apps and packages                      |
+| `pnpm lint`                    | Lint all apps and packages                       |
+| `pnpm format`                  | Format with Prettier                             |
+| `pnpm --filter web db:migrate` | Apply Drizzle migrations                         |
+| `pnpm --filter web db:seed`    | Seed Mexican states                              |
+| `pnpm --filter web db:studio`  | Open Drizzle Studio                              |
 
 ## Tech Stack
 

--- a/apps/web/app/(root)/competitions/[id]/results/all/_lib/queries.ts
+++ b/apps/web/app/(root)/competitions/[id]/results/all/_lib/queries.ts
@@ -10,13 +10,124 @@ import {
   resultAttempts,
 } from "@workspace/db/schema";
 import { eventNames } from "@/lib/constants";
-import { eq, inArray } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 import {
   type CompetitionResultRow,
   type ResultsByEventGroup,
 } from "../../../_lib/results";
 import { roundTypeLabel, roundRank } from "@/lib/utils";
+
+function groupRowsByRounds(
+  eventId: string,
+  rowsWithSolves: CompetitionResultRow[],
+): ResultsByEventGroup {
+  const roundsMap = rowsWithSolves.reduce((accumulator, resultRow) => {
+    const roundId = resultRow.roundTypeId ?? "";
+    const list = accumulator.get(roundId) ?? [];
+    list.push(resultRow);
+    accumulator.set(roundId, list);
+    return accumulator;
+  }, new Map<string, CompetitionResultRow[]>());
+
+  return {
+    eventId,
+    eventName: eventNames[eventId] || eventId,
+    rounds: Array.from(roundsMap.entries())
+      .map(([roundTypeId, rows]) => ({
+        roundTypeId,
+        roundLabel: roundTypeLabel(roundTypeId),
+        rows: rows
+          .slice()
+          .sort(
+            (left, right) =>
+              left.eventRank - right.eventRank ||
+              (left.position ?? 999) - (right.position ?? 999),
+          ),
+      }))
+      .sort((a, b) => roundRank(a.roundTypeId) - roundRank(b.roundTypeId)),
+  };
+}
+
+export async function getCompetitionResultsForEvent(
+  competitionId: string,
+  eventId: string,
+): Promise<ResultsByEventGroup | null> {
+  cacheLife("weeks");
+  cacheTag(`competition-results-all-${competitionId}-${eventId}`);
+
+  if (!eventId) {
+    return null;
+  }
+
+  try {
+    const rows = await db
+      .select({
+        resultId: result.id,
+        eventId: result.eventId,
+        eventName: event.name,
+        eventRank: event.rank,
+        personId: result.personId,
+        personName: person.name,
+        personState: state.name,
+        roundTypeId: result.roundTypeId,
+        position: result.pos,
+        best: result.best,
+        average: result.average,
+      })
+      .from(result)
+      .innerJoin(event, eq(result.eventId, event.id))
+      .innerJoin(person, eq(result.personId, person.wcaId))
+      .leftJoin(state, eq(person.stateId, state.id))
+      .where(
+        and(
+          eq(result.competitionId, competitionId),
+          eq(result.eventId, eventId),
+        ),
+      )
+      .orderBy(result.pos, result.best);
+
+    if (rows.length === 0) {
+      return {
+        eventId,
+        eventName: eventNames[eventId] || eventId,
+        rounds: [],
+      };
+    }
+
+    const attempts = await db
+      .select({
+        resultId: resultAttempts.resultId,
+        attemptNumber: resultAttempts.attemptNumber,
+        value: resultAttempts.value,
+      })
+      .from(resultAttempts)
+      .where(
+        inArray(
+          resultAttempts.resultId,
+          rows.map((row) => row.resultId),
+        ),
+      )
+      .orderBy(resultAttempts.resultId, resultAttempts.attemptNumber);
+
+    const attemptsByResultId = attempts.reduce((accumulator, attempt) => {
+      const values = accumulator.get(attempt.resultId) ?? [];
+      values.push(attempt.value);
+      accumulator.set(attempt.resultId, values);
+      return accumulator;
+    }, new Map<string, number[]>());
+
+    const rowsWithSolves = rows.map((row) => ({
+      ...row,
+      solves: attemptsByResultId.get(row.resultId) ?? [],
+    }));
+
+    return groupRowsByRounds(eventId, rowsWithSolves);
+  } catch (err) {
+    console.error(err);
+    return null;
+  }
+}
 
 export async function getCompetitionResultsGroupedByEvent(
   competitionId: string,
@@ -79,24 +190,25 @@ export async function getCompetitionResultsGroupedByEvent(
 
     return Array.from(
       rowsWithSolves.reduce((accumulator, resultRow) => {
-        const eventId = resultRow.eventId ?? "";
+        const rowEventId = resultRow.eventId ?? "";
         const rounds =
-          accumulator.get(eventId) ?? new Map<string, CompetitionResultRow[]>();
+          accumulator.get(rowEventId) ??
+          new Map<string, CompetitionResultRow[]>();
         const roundId = resultRow.roundTypeId ?? "";
         const list = rounds.get(roundId) ?? [];
         list.push(resultRow);
         rounds.set(roundId, list);
-        accumulator.set(eventId, rounds);
+        accumulator.set(rowEventId, rounds);
         return accumulator;
       }, new Map<string, Map<string, CompetitionResultRow[]>>()),
-    ).map(([eventId, roundsMap]) => ({
-      eventId,
-      eventName: eventNames[eventId] || eventId,
+    ).map(([rowEventId, roundsMap]) => ({
+      eventId: rowEventId,
+      eventName: eventNames[rowEventId] || rowEventId,
       rounds: Array.from(roundsMap.entries())
-        .map(([roundTypeId, rows]) => ({
+        .map(([roundTypeId, roundRows]) => ({
           roundTypeId,
           roundLabel: roundTypeLabel(roundTypeId),
-          rows: rows
+          rows: roundRows
             .slice()
             .sort(
               (left, right) =>

--- a/apps/web/app/(root)/competitions/[id]/results/all/page.tsx
+++ b/apps/web/app/(root)/competitions/[id]/results/all/page.tsx
@@ -1,13 +1,60 @@
 import { notFound } from "next/navigation";
 import { getCompetitions } from "@/db/queries";
 import { getWcaCompetitionData } from "../../_lib/queries";
-import { getCompetitionResultsGroupedByEvent } from "./_lib/queries";
+import { getCompetitionResultsForEvent } from "./_lib/queries";
 import { ResultsHeader } from "../_components/results-header";
 import { ResultsAllView } from "../_components/results-views";
+import { cacheLife, cacheTag } from "next/cache";
 
 export async function generateStaticParams() {
   const competitions = await getCompetitions();
   return competitions.map((competition) => ({ id: competition.id }));
+}
+
+async function ResultsAllCached({
+  competitionId,
+  eventId,
+  competitionName,
+  competitionCity,
+  eventIds,
+  mainEventId,
+}: {
+  competitionId: string;
+  eventId: string;
+  competitionName: string;
+  competitionCity: string;
+  eventIds: string[];
+  mainEventId: string | null;
+}) {
+  "use cache";
+  cacheLife("weeks");
+  cacheTag(`competition-results-all-page-${competitionId}-${eventId}`);
+
+  const eventResults = await getCompetitionResultsForEvent(
+    competitionId,
+    eventId,
+  );
+  const groupedResultsByEvent = eventResults ? [eventResults] : [];
+
+  return (
+    <main className="grow container mx-auto px-4 py-8 space-y-6">
+      <ResultsHeader
+        competitionId={competitionId}
+        competitionName={competitionName}
+        competitionCity={competitionCity}
+        defaultEventId={eventId}
+      />
+      <ResultsAllView
+        competitionId={competitionId}
+        competitionData={{
+          event_ids: eventIds,
+          main_event_id: mainEventId,
+        }}
+        groupedResultsByEvent={groupedResultsByEvent}
+        selectedEventId={eventId}
+      />
+    </main>
+  );
 }
 
 export default async function Page({
@@ -19,11 +66,7 @@ export default async function Page({
 }) {
   const [{ id }, searchParamsValue] = await Promise.all([params, searchParams]);
 
-  const [competitionData, groupedResultsByEvent] = await Promise.all([
-    getWcaCompetitionData(id),
-    getCompetitionResultsGroupedByEvent(id),
-  ]);
-
+  const competitionData = await getWcaCompetitionData(id);
   if (!competitionData) {
     notFound();
   }
@@ -39,19 +82,13 @@ export default async function Page({
     defaultEventId;
 
   return (
-    <main className="grow container mx-auto px-4 py-8 space-y-6">
-      <ResultsHeader
-        competitionId={competitionData.id}
-        competitionName={competitionData.name}
-        competitionCity={competitionData.city}
-        defaultEventId={selectedEventId}
-      />
-      <ResultsAllView
-        competitionId={competitionData.id}
-        competitionData={competitionData}
-        groupedResultsByEvent={groupedResultsByEvent}
-        selectedEventId={selectedEventId}
-      />
-    </main>
+    <ResultsAllCached
+      competitionId={competitionData.id}
+      eventId={selectedEventId}
+      competitionName={competitionData.name}
+      competitionCity={competitionData.city}
+      eventIds={competitionData.event_ids}
+      mainEventId={competitionData.main_event_id}
+    />
   );
 }

--- a/apps/web/app/(root)/layout.tsx
+++ b/apps/web/app/(root)/layout.tsx
@@ -2,14 +2,11 @@ import { Header } from "@/components/header";
 import { Footer } from "@/components/footer";
 import { Suspense } from "react";
 import { FooterSkeleton } from "@/components/footer-skeleton";
-import { HeaderSkeleton } from "@/components/header-skeleton";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex flex-col min-h-screen">
-      <Suspense fallback={<HeaderSkeleton />}>
-        <Header />
-      </Suspense>
+      <Header />
       {children}
       <Suspense fallback={<FooterSkeleton />}>
         <Footer />

--- a/apps/web/app/(root)/persons/[id]/_components/person-tabs.tsx
+++ b/apps/web/app/(root)/persons/[id]/_components/person-tabs.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { parseAsString, parseAsStringLiteral, useQueryStates } from "nuqs";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@workspace/ui/components/tabs";
+import { Badge } from "@workspace/ui/components/badge";
+import { Skeleton } from "@workspace/ui/components/skeleton";
+import { cn } from "@workspace/ui/lib/utils";
+import type { GeoJSONProps } from "react-leaflet";
+import { PersonResultsTab } from "./results-tab";
+import { PersonResultsChartTab } from "./results-chart-tab";
+import { PersonRecordsTab } from "./records-tab";
+import { PersonChampionshipPodiumsTab } from "./championship-podiums-tab";
+import { PersonStaffCompetitionsTab } from "./staff-competitions-tab";
+import { MapContainer } from "./map-container";
+import type {
+  PersonChampionshipPodium,
+  PersonRecordHistoryEntry,
+  PersonResultsByEventGroup,
+  PersonResultsEventOption,
+  PersonStaffCompetition,
+} from "../_lib/queries";
+import type { PersonCompetitionLocation } from "../_lib/queries";
+import {
+  loadPersonChampionshipPodiums,
+  loadPersonCompetitionResults,
+  loadPersonMapData,
+  loadPersonRecordHistory,
+  loadPersonStaffCompetitions,
+} from "../_lib/actions";
+
+const TAB_VALUES = [
+  "results-by-event",
+  "results-chart",
+  "records",
+  "championship-podiums",
+  "map",
+  "staff-competitions",
+] as const;
+
+type TabValue = (typeof TAB_VALUES)[number];
+
+type PersonTabsProps = {
+  wcaId: string;
+  eventOptions: PersonResultsEventOption[];
+  showRecordsTab: boolean;
+};
+
+export function PersonTabs({
+  wcaId,
+  eventOptions,
+  showRecordsTab,
+}: PersonTabsProps) {
+  const [{ tab, event }, setQuery] = useQueryStates({
+    tab: parseAsStringLiteral(TAB_VALUES).withDefault("results-by-event"),
+    event: parseAsString.withDefault(eventOptions[0]?.eventId ?? ""),
+  });
+
+  const selectedEventId =
+    eventOptions.find((option) => option.eventId === event)?.eventId ??
+    eventOptions[0]?.eventId ??
+    "";
+
+  const [isPending, startTransition] = useTransition();
+  const [selectedResults, setSelectedResults] =
+    useState<PersonResultsByEventGroup | null>(null);
+  const [recordHistory, setRecordHistory] = useState<
+    PersonRecordHistoryEntry[] | null
+  >(null);
+  const [championshipPodiums, setChampionshipPodiums] = useState<
+    PersonChampionshipPodium[] | null
+  >(null);
+  const [staffCompetitions, setStaffCompetitions] = useState<{
+    organized: PersonStaffCompetition[];
+    delegated: PersonStaffCompetition[];
+  } | null>(null);
+  const [mapData, setMapData] = useState<{
+    locations: PersonCompetitionLocation[];
+    statesData: GeoJSONProps["data"] | undefined;
+    visitedStateCount: number;
+  } | null>(null);
+
+  useEffect(() => {
+    if (
+      (tab !== "results-by-event" && tab !== "results-chart") ||
+      !selectedEventId
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+    startTransition(() => {
+      void loadPersonCompetitionResults(wcaId, selectedEventId).then(
+        (results) => {
+          if (!cancelled) {
+            setSelectedResults(results);
+          }
+        },
+      );
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [wcaId, selectedEventId, tab]);
+
+  useEffect(() => {
+    if (tab !== "records" || recordHistory !== null) {
+      return;
+    }
+
+    let cancelled = false;
+    startTransition(() => {
+      void loadPersonRecordHistory(wcaId).then((history) => {
+        if (!cancelled) {
+          setRecordHistory(history);
+        }
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [tab, wcaId, recordHistory]);
+
+  useEffect(() => {
+    if (tab !== "championship-podiums" || championshipPodiums !== null) {
+      return;
+    }
+
+    let cancelled = false;
+    startTransition(() => {
+      void loadPersonChampionshipPodiums(wcaId).then((podiums) => {
+        if (!cancelled) {
+          setChampionshipPodiums(podiums);
+        }
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [tab, wcaId, championshipPodiums]);
+
+  useEffect(() => {
+    if (tab !== "staff-competitions" || staffCompetitions !== null) {
+      return;
+    }
+
+    let cancelled = false;
+    startTransition(() => {
+      void loadPersonStaffCompetitions(wcaId).then((staff) => {
+        if (!cancelled) {
+          setStaffCompetitions(staff);
+        }
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [tab, wcaId, staffCompetitions]);
+
+  useEffect(() => {
+    if (tab !== "map" || mapData !== null) {
+      return;
+    }
+
+    let cancelled = false;
+    startTransition(() => {
+      void loadPersonMapData(wcaId).then((data) => {
+        if (!cancelled) {
+          setMapData({
+            locations: data.locations,
+            statesData: data.statesData as GeoJSONProps["data"] | undefined,
+            visitedStateCount: data.visitedStateCount,
+          });
+        }
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [tab, wcaId, mapData]);
+
+  const hasStaffCompetitions =
+    staffCompetitions !== null &&
+    (staffCompetitions.organized.length > 0 ||
+      staffCompetitions.delegated.length > 0);
+
+  const hasPodiums =
+    championshipPodiums !== null && championshipPodiums.length > 0;
+
+  // Always reserve slots for optional tabs that load on demand.
+  const tabCount = 5 + (showRecordsTab ? 1 : 0);
+
+  function selectTab(nextTab: TabValue) {
+    void setQuery({ tab: nextTab });
+  }
+
+  function selectEvent(eventId: string) {
+    void setQuery({ event: eventId });
+  }
+
+  return (
+    <Tabs
+      value={tab}
+      onValueChange={(value) => selectTab(value as TabValue)}
+      className="mt-6"
+    >
+      <TabsList
+        className={cn(
+          "flex flex-col h-auto w-full gap-1.5 p-1.5",
+          "md:h-10 md:grid",
+          tabCount === 2 && "md:grid-cols-2",
+          tabCount === 3 && "md:grid-cols-3",
+          tabCount === 4 && "md:grid-cols-4",
+          tabCount === 5 && "md:grid-cols-5",
+          tabCount >= 6 && "md:grid-cols-6",
+        )}
+      >
+        <TabsTrigger value="results-by-event">Resultados</TabsTrigger>
+        <TabsTrigger value="results-chart">Gráfica</TabsTrigger>
+        {showRecordsTab && <TabsTrigger value="records">Récords</TabsTrigger>}
+        <TabsTrigger value="championship-podiums">
+          Podios en Campeonatos
+        </TabsTrigger>
+        <TabsTrigger value="map">Mapa</TabsTrigger>
+        <TabsTrigger value="staff-competitions">Organización</TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="results-by-event" className="mt-6">
+        {isPending && !selectedResults ? (
+          <Skeleton className="h-64 w-full" />
+        ) : (
+          <PersonResultsTab
+            eventOptions={eventOptions}
+            selectedEventId={selectedEventId}
+            selectedResults={selectedResults}
+            onEventSelect={selectEvent}
+          />
+        )}
+      </TabsContent>
+
+      <TabsContent value="results-chart" className="mt-6">
+        {isPending && !selectedResults ? (
+          <Skeleton className="h-64 w-full" />
+        ) : (
+          <PersonResultsChartTab
+            eventOptions={eventOptions}
+            selectedEventId={selectedEventId}
+            selectedResults={selectedResults}
+            onEventSelect={selectEvent}
+          />
+        )}
+      </TabsContent>
+
+      {showRecordsTab && (
+        <TabsContent value="records" className="mt-6">
+          {recordHistory === null ? (
+            <Skeleton className="h-64 w-full" />
+          ) : (
+            <PersonRecordsTab records={recordHistory} />
+          )}
+        </TabsContent>
+      )}
+
+      <TabsContent value="championship-podiums" className="mt-6">
+        {championshipPodiums === null ? (
+          <Skeleton className="h-64 w-full" />
+        ) : hasPodiums ? (
+          <PersonChampionshipPodiumsTab podiums={championshipPodiums} />
+        ) : (
+          <p className="text-sm text-muted-foreground text-center">
+            Esta persona no tiene podios en campeonatos.
+          </p>
+        )}
+      </TabsContent>
+
+      <TabsContent value="map" className="mt-6">
+        {mapData === null ? (
+          <Skeleton className="h-64 w-full" />
+        ) : (
+          <>
+            <h2 className="flex items-center justify-center gap-2 text-lg font-semibold my-4">
+              <span>Estados visitados</span>
+              <Badge>{mapData.visitedStateCount}</Badge>
+            </h2>
+            <MapContainer
+              locations={mapData.locations}
+              statesData={mapData.statesData as GeoJSONProps["data"]}
+            />
+          </>
+        )}
+      </TabsContent>
+
+      <TabsContent value="staff-competitions" className="mt-6">
+        {staffCompetitions === null ? (
+          <Skeleton className="h-64 w-full" />
+        ) : hasStaffCompetitions ? (
+          <PersonStaffCompetitionsTab
+            organized={staffCompetitions.organized}
+            delegated={staffCompetitions.delegated}
+          />
+        ) : (
+          <p className="text-sm text-muted-foreground text-center">
+            Esta persona no ha organizado ni delegado competencias.
+          </p>
+        )}
+      </TabsContent>
+    </Tabs>
+  );
+}

--- a/apps/web/app/(root)/persons/[id]/_components/results-chart-tab.tsx
+++ b/apps/web/app/(root)/persons/[id]/_components/results-chart-tab.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useMemo } from "react";
 import {
   CartesianGrid,
@@ -40,6 +39,7 @@ type PersonResultsChartTabProps = {
   eventOptions: PersonResultsEventOption[];
   selectedEventId: string;
   selectedResults: PersonResultsByEventGroup | null;
+  onEventSelect?: (eventId: string) => void;
 };
 
 type SessionPoint = {
@@ -180,6 +180,7 @@ export function PersonResultsChartTab({
   eventOptions,
   selectedEventId,
   selectedResults,
+  onEventSelect,
 }: PersonResultsChartTabProps) {
   const points = useMemo<SessionPoint[]>(() => {
     if (!selectedResults) {
@@ -421,9 +422,10 @@ export function PersonResultsChartTab({
       <CardHeader className="space-y-6">
         <div className="flex flex-wrap justify-center gap-2 text-muted-foreground">
           {eventOptions.map((group) => (
-            <Link
+            <button
               key={group.eventId}
-              href={`?tab=results-chart&event=${group.eventId}`}
+              type="button"
+              onClick={() => onEventSelect?.(group.eventId)}
               className={cn(
                 `cubing-icon event-${group.eventId} text-3xl hover:text-primary/50 transition-colors`,
                 selectedEventId === group.eventId && "text-primary",

--- a/apps/web/app/(root)/persons/[id]/_components/results-tab.tsx
+++ b/apps/web/app/(root)/persons/[id]/_components/results-tab.tsx
@@ -24,6 +24,7 @@ type PersonResultsTabProps = {
   eventOptions: PersonResultsEventOption[];
   selectedEventId: string;
   selectedResults: PersonResultsByEventGroup | null;
+  onEventSelect?: (eventId: string) => void;
 };
 
 function getPodiumRowClass(
@@ -51,6 +52,7 @@ export function PersonResultsTab({
   eventOptions,
   selectedEventId,
   selectedResults,
+  onEventSelect,
 }: PersonResultsTabProps) {
   if (eventOptions.length === 0 || !selectedResults) {
     return (
@@ -86,20 +88,17 @@ export function PersonResultsTab({
     <Card>
       <CardHeader className="space-y-6">
         <div className="flex flex-wrap justify-center gap-2 text-muted-foreground">
-          {eventOptions.map((group) => {
-            const href = `?tab=results-by-event&event=${group.eventId}`;
-
-            return (
-              <Link
-                key={group.eventId}
-                href={href}
-                className={cn(
-                  `cubing-icon event-${group.eventId} text-3xl hover:text-primary/50 transition-colors`,
-                  selectedEventId === group.eventId && "text-primary",
-                )}
-              />
-            );
-          })}
+          {eventOptions.map((group) => (
+            <button
+              key={group.eventId}
+              type="button"
+              onClick={() => onEventSelect?.(group.eventId)}
+              className={cn(
+                `cubing-icon event-${group.eventId} text-3xl hover:text-primary/50 transition-colors`,
+                selectedEventId === group.eventId && "text-primary",
+              )}
+            />
+          ))}
         </div>
         <CardTitle className="flex items-center gap-2">
           <span

--- a/apps/web/app/(root)/persons/[id]/_lib/actions.ts
+++ b/apps/web/app/(root)/persons/[id]/_lib/actions.ts
@@ -1,0 +1,56 @@
+"use server";
+
+import {
+  getPersonChampionshipPodiums,
+  getPersonCompetitionLocations,
+  getPersonCompetitionResults,
+  getPersonRecordHistory,
+  getPersonStaffCompetitions,
+} from "./queries";
+import { getStatesGeoJSON } from "@/db/queries";
+
+export async function loadPersonCompetitionResults(
+  wcaId: string,
+  eventId: string,
+) {
+  return getPersonCompetitionResults(wcaId, eventId);
+}
+
+export async function loadPersonRecordHistory(wcaId: string) {
+  return getPersonRecordHistory(wcaId);
+}
+
+export async function loadPersonChampionshipPodiums(wcaId: string) {
+  return getPersonChampionshipPodiums(wcaId);
+}
+
+export async function loadPersonStaffCompetitions(wcaId: string) {
+  return getPersonStaffCompetitions(wcaId);
+}
+
+export async function loadPersonMapData(wcaId: string) {
+  const [locations, statesData] = await Promise.all([
+    getPersonCompetitionLocations(wcaId),
+    getStatesGeoJSON(),
+  ]);
+
+  const stateIds = locations
+    .map((location) => location.stateId)
+    .filter((stateId): stateId is string => stateId !== null);
+
+  const filteredStatesData = statesData?.features.filter((feature) =>
+    stateIds.includes(feature.properties.id),
+  );
+
+  const filteredLocations = locations.filter((location) => {
+    const latitude = location.latitude ?? 0;
+    const longitude = location.longitude ?? 0;
+    return latitude !== 0 && longitude !== 0;
+  });
+
+  return {
+    locations: filteredLocations,
+    statesData: filteredStatesData,
+    visitedStateCount: new Set(stateIds).size,
+  };
+}

--- a/apps/web/app/(root)/persons/[id]/page.tsx
+++ b/apps/web/app/(root)/persons/[id]/page.tsx
@@ -9,7 +9,7 @@ import {
   TableCell,
 } from "@workspace/ui/components/table";
 import Image from "next/image";
-import { getEvents, getPerson, getStatesGeoJSON } from "@/db/queries";
+import { getEvents, getPerson } from "@/db/queries";
 import {
   formatTime,
   formatTime333mbf,
@@ -24,42 +24,23 @@ import {
 } from "@workspace/ui/components/tooltip";
 import { cn } from "@workspace/ui/lib/utils";
 import { Badge } from "@workspace/ui/components/badge";
-import type { GeoJSONProps } from "react-leaflet";
 import Link from "next/link";
 import type { Metadata } from "next";
-import {
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from "@workspace/ui/components/tabs";
-import { MapContainer } from "./_components/map-container";
-import { PersonResultsTab } from "./_components/results-tab";
-import { PersonStaffCompetitionsTab } from "./_components/staff-competitions-tab";
 import {
   getPersonData,
   getOrganizerStatus,
   getMembershipData,
   getPersonCompetitionEventOptions,
-  getPersonCompetitionLocations,
-  getPersonCompetitionResults,
   getPersonDataFromWCA,
-  getPersonStaffCompetitions,
-  getPersonRecordHistory,
-  getPersonChampionshipPodiums,
 } from "./_lib/queries";
 import type { PersonalRecordWithStateRank } from "./_lib/queries";
-import { PersonRecordsTab } from "./_components/records-tab";
-import { PersonChampionshipPodiumsTab } from "./_components/championship-podiums-tab";
 import { notFound } from "next/navigation";
 import { cacheLife, cacheTag } from "next/cache";
 import { formatDelegateLevel } from "@/lib/delegate-level";
-import type { SearchParams } from "@/types";
-import { PersonResultsChartTab } from "./_components/results-chart-tab";
+import { PersonTabs } from "./_components/person-tabs";
 
 type Props = {
   params: Promise<{ id: string }>;
-  searchParams: Promise<SearchParams>;
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -88,69 +69,28 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-async function PersonPageContent({
-  id,
-  searchParams,
-}: {
-  id: string;
-  searchParams: Promise<SearchParams>;
-}) {
+async function PersonPageContent({ id }: { id: string }) {
   "use cache";
   cacheLife("days");
   cacheTag(`person-page-${id}`);
 
   const events = await getEvents();
-  const queryParams = await searchParams;
-  const requestedEventId = Array.isArray(queryParams.event)
-    ? queryParams.event[0]
-    : queryParams.event;
-  const selectedTab = (() => {
-    const raw = Array.isArray(queryParams.tab)
-      ? queryParams.tab[0]
-      : queryParams.tab;
-    const valid = [
-      "results-by-event",
-      "results-chart",
-      "records",
-      "championship-podiums",
-      "map",
-      "staff-competitions",
-    ];
-    return valid.includes(raw ?? "")
-      ? (raw ?? "results-by-event")
-      : "results-by-event";
-  })();
-
   const wcaData = await getPersonDataFromWCA(id);
 
   if (!wcaData) {
     notFound();
   }
 
-  const [
-    personData,
-    organizerStatus,
-    membershipData,
-    eventOptions,
-    locations,
-    statesData,
-    staffCompetitions,
-    recordHistory,
-    championshipPodiums,
-  ] = await Promise.all([
-    getPersonData(id),
-    getOrganizerStatus(id),
-    getMembershipData(
-      id,
-      events.map((event) => event.id),
-    ),
-    getPersonCompetitionEventOptions(id),
-    getPersonCompetitionLocations(id),
-    getStatesGeoJSON(),
-    getPersonStaffCompetitions(id),
-    getPersonRecordHistory(id),
-    getPersonChampionshipPodiums(id),
-  ]);
+  const [personData, organizerStatus, membershipData, eventOptions] =
+    await Promise.all([
+      getPersonData(id),
+      getOrganizerStatus(id),
+      getMembershipData(
+        id,
+        events.map((event) => event.id),
+      ),
+      getPersonCompetitionEventOptions(id),
+    ]);
 
   if (!personData) {
     notFound();
@@ -158,45 +98,10 @@ async function PersonPageContent({
 
   const { person, competitionCount, personalRecords, medals, regionalRecords } =
     personData;
-  const { organized, delegated } = staffCompetitions;
-  const hasStaffCompetitions = organized.length > 0 || delegated.length > 0;
   const isOrganizer = organizerStatus !== null;
-  const hasRecords = regionalRecords.total > 0;
-  const hasPodiums = championshipPodiums.length > 0;
-  const tabCount =
-    3 +
-    (hasRecords ? 1 : 0) +
-    (hasPodiums ? 1 : 0) +
-    (hasStaffCompetitions ? 1 : 0);
-
-  const stateIds = locations
-    .map((location) => location.stateId)
-    .filter((stateId): stateId is string => stateId !== null);
-
-  const filteredStatesData = statesData?.features.filter((feature) =>
-    stateIds?.includes(feature.properties.id),
-  ) as unknown as GeoJSONProps["data"];
-
-  const visitedStateCount = new Set(stateIds).size;
-
-  const filteredLocations = locations.filter((location) => {
-    const latitude = location.latitude ?? 0;
-    const longitude = location.longitude ?? 0;
-
-    return latitude !== 0 && longitude !== 0;
-  });
-
   const isDelegate = person.delegateStatus !== null;
-
   const tier = getTier(membershipData);
-  const selectedEventId =
-    eventOptions.find((e) => e.eventId === requestedEventId)?.eventId ??
-    eventOptions[0]?.eventId ??
-    "";
-
-  const selectedResults = selectedEventId
-    ? await getPersonCompetitionResults(id, selectedEventId)
-    : null;
+  const showRecordsTab = regionalRecords.total > 0;
 
   const records = events.reduce<
     Array<{ event: string; record: PersonalRecordWithStateRank }>
@@ -261,7 +166,6 @@ async function PersonPageContent({
             <TableHead className="text-center">WCA ID</TableHead>
             <TableHead className="text-center">Sexo</TableHead>
             <TableHead className="text-center">Competencias</TableHead>
-            {/* <TableHead className="text-center">Resoluciones</TableHead> */}
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -280,7 +184,6 @@ async function PersonPageContent({
                   : "Otro"}
             </TableCell>
             <TableCell className="text-center">{competitionCount}</TableCell>
-            {/* <TableCell className="text-center">{solveCount}</TableCell> */}
           </TableRow>
         </TableBody>
       </Table>
@@ -505,152 +408,17 @@ async function PersonPageContent({
           </Table>
         </div>
       </div>
-      <Tabs value={selectedTab} className="mt-6">
-        <TabsList
-          className={cn(
-            "flex flex-col h-auto w-full gap-1.5 p-1.5",
-            "md:h-10 md:grid",
-            tabCount === 2 && "md:grid-cols-2",
-            tabCount === 3 && "md:grid-cols-3",
-            tabCount === 4 && "md:grid-cols-4",
-            tabCount === 5 && "md:grid-cols-5",
-            tabCount >= 6 && "md:grid-cols-6",
-          )}
-        >
-          <TabsTrigger value="results-by-event" asChild>
-            <Link
-              href={
-                selectedEventId
-                  ? `?tab=results-by-event&event=${selectedEventId}`
-                  : "?tab=results-by-event"
-              }
-            >
-              Resultados
-            </Link>
-          </TabsTrigger>
-          <TabsTrigger value="results-chart" asChild>
-            <Link
-              href={
-                selectedEventId
-                  ? `?tab=results-chart&event=${selectedEventId}`
-                  : "?tab=results-chart"
-              }
-            >
-              Gráfica
-            </Link>
-          </TabsTrigger>
-          {hasRecords && (
-            <TabsTrigger value="records" asChild>
-              <Link
-                href={
-                  selectedEventId
-                    ? `?tab=records&event=${selectedEventId}`
-                    : "?tab=records"
-                }
-              >
-                Récords
-              </Link>
-            </TabsTrigger>
-          )}
-          {hasPodiums && (
-            <TabsTrigger value="championship-podiums" asChild>
-              <Link
-                href={
-                  selectedEventId
-                    ? `?tab=championship-podiums&event=${selectedEventId}`
-                    : "?tab=championship-podiums"
-                }
-              >
-                Podios en Campeonatos
-              </Link>
-            </TabsTrigger>
-          )}
-          <TabsTrigger value="map" asChild>
-            <Link
-              href={
-                selectedEventId
-                  ? `?tab=map&event=${selectedEventId}`
-                  : "?tab=map"
-              }
-            >
-              Mapa
-            </Link>
-          </TabsTrigger>
-          {hasStaffCompetitions && (
-            <TabsTrigger value="staff-competitions" asChild>
-              <Link
-                href={
-                  selectedEventId
-                    ? `?tab=staff-competitions&event=${selectedEventId}`
-                    : "?tab=staff-competitions"
-                }
-              >
-                Organización
-              </Link>
-            </TabsTrigger>
-          )}
-        </TabsList>
-
-        <TabsContent value="results-by-event" className="mt-6">
-          <PersonResultsTab
-            eventOptions={eventOptions}
-            selectedEventId={selectedEventId}
-            selectedResults={selectedResults}
-          />
-        </TabsContent>
-
-        <TabsContent value="results-chart" className="mt-6">
-          <PersonResultsChartTab
-            eventOptions={eventOptions}
-            selectedEventId={selectedEventId}
-            selectedResults={selectedResults}
-          />
-        </TabsContent>
-
-        {hasRecords && (
-          <TabsContent value="records" className="mt-6">
-            <PersonRecordsTab records={recordHistory} />
-          </TabsContent>
-        )}
-
-        {hasPodiums && (
-          <TabsContent value="championship-podiums" className="mt-6">
-            <PersonChampionshipPodiumsTab podiums={championshipPodiums} />
-          </TabsContent>
-        )}
-
-        <TabsContent value="map" className="mt-6">
-          <h2 className="flex items-center justify-center gap-2 text-lg font-semibold my-4">
-            <span>Estados visitados</span>
-            <Badge>{visitedStateCount}</Badge>
-          </h2>
-          <MapContainer
-            locations={filteredLocations}
-            statesData={filteredStatesData}
-          />
-        </TabsContent>
-
-        {hasStaffCompetitions && (
-          <TabsContent value="staff-competitions" className="mt-6">
-            <PersonStaffCompetitionsTab
-              organized={organized}
-              delegated={delegated}
-            />
-          </TabsContent>
-        )}
-      </Tabs>
+      <PersonTabs
+        wcaId={id}
+        eventOptions={eventOptions}
+        showRecordsTab={showRecordsTab}
+      />
     </>
   );
 }
 
-export default async function Page({
-  params,
-  searchParams,
-}: {
-  params: Promise<{ id: string }>;
-  searchParams: Promise<SearchParams>;
-}) {
+export default async function Page({ params }: Props) {
   const id = (await params).id;
 
-  return <PersonPageContent id={id} searchParams={searchParams} />;
+  return <PersonPageContent id={id} />;
 }

--- a/apps/web/app/actions.ts
+++ b/apps/web/app/actions.ts
@@ -5,6 +5,7 @@ import {
   addMember,
   deleteTeamCover,
   deleteTeamLogo,
+  getCurrentUserTeam,
   saveProfile,
   saveTeam,
   updateTeamCover,
@@ -25,6 +26,10 @@ export async function signInAction(provider?: string) {
 
 export async function signOutAction() {
   await signOut();
+}
+
+export async function getCurrentUserTeamAction(userId: string) {
+  return getCurrentUserTeam({ userId });
 }
 
 export async function profileFormAction(

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -4,7 +4,6 @@ import "@cubing/icons";
 import { Providers } from "@/components/providers";
 import type { Metadata } from "next";
 import { Analytics } from "@vercel/analytics/react";
-import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Toaster } from "sonner";
 import { WebVitals } from "@/components/web-vitals";
 
@@ -42,7 +41,6 @@ export default function RootLayout({
         <WebVitals />
         <Providers>{children}</Providers>
         <Analytics />
-        <SpeedInsights />
         <Toaster />
       </body>
     </html>

--- a/apps/web/components/footer.tsx
+++ b/apps/web/components/footer.tsx
@@ -8,12 +8,14 @@ import { Clock, Trophy } from "lucide-react";
 import Link from "next/link";
 import { ThemeToggle } from "./theme-toggle";
 import { getLastCompetitionWithResults } from "@/db/queries";
-import { connection } from "next/server";
+import { cacheLife, cacheTag } from "next/cache";
 
-export async function Footer() {
-  await connection();
+async function FooterContent() {
+  "use cache";
+  cacheLife("days");
+  cacheTag("site-footer");
+
   const currentYear = new Date().getFullYear();
-
   const competitions = await getLastCompetitionWithResults();
 
   return (
@@ -109,4 +111,8 @@ export async function Footer() {
       </div>
     </footer>
   );
+}
+
+export function Footer() {
+  return <FooterContent />;
 }

--- a/apps/web/components/header-auth.tsx
+++ b/apps/web/components/header-auth.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
+import { Skeleton } from "@workspace/ui/components/skeleton";
+import { getCurrentUserTeamAction } from "@/app/actions";
+import { UserAuthForm } from "./user-auth-form";
+import { UserDropdown } from "./user-dropdown";
+
+type Team = {
+  id: string;
+  name: string;
+} | null;
+
+export function HeaderAuth() {
+  const { data: session, status } = useSession();
+  const [team, setTeam] = useState<Team>(null);
+
+  useEffect(() => {
+    const userId = session?.user?.id;
+    if (!userId) {
+      setTeam(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    void getCurrentUserTeamAction(userId).then((result) => {
+      if (!cancelled) {
+        setTeam(result);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [session?.user?.id]);
+
+  if (status === "loading") {
+    return <Skeleton className="size-12 rounded-full" />;
+  }
+
+  if (!session?.user) {
+    return <UserAuthForm />;
+  }
+
+  return <UserDropdown user={session.user} team={team} />;
+}

--- a/apps/web/components/header.tsx
+++ b/apps/web/components/header.tsx
@@ -1,36 +1,9 @@
 import Link from "next/link";
 import { CubingMexico } from "@workspace/icons";
-import { UserDropdown } from "./user-dropdown";
 import { HeaderNavigationMenu } from "./header-navigation-menu";
-import { auth } from "@/auth";
-import { getCurrentUserTeam } from "@/db/queries";
-import { UserAuthForm } from "./user-auth-form";
+import { HeaderAuth } from "./header-auth";
 
-export async function Header() {
-  const session = await auth();
-
-  if (!session) {
-    return (
-      <header className="bg-primary text-primary-foreground body-font top-0 z-50">
-        <div className="mx-auto flex flex-col sm:flex-row items-center gap-8 justify-between p-5">
-          <div className="flex flex-col sm:flex-row justify-between items-center gap-8">
-            <Link href="/">
-              <CubingMexico className="size-16" />
-            </Link>
-            <HeaderNavigationMenu />
-          </div>
-          <UserAuthForm />
-        </div>
-      </header>
-    );
-  }
-
-  const user = session.user!;
-
-  const team = await getCurrentUserTeam({
-    userId: user.id!,
-  });
-
+export function Header() {
   return (
     <header className="bg-primary text-primary-foreground body-font top-0 z-50">
       <div className="mx-auto flex flex-col sm:flex-row items-center gap-8 justify-between p-5">
@@ -40,7 +13,7 @@ export async function Header() {
           </Link>
           <HeaderNavigationMenu />
         </div>
-        <UserDropdown user={user} team={team} />
+        <HeaderAuth />
       </div>
     </header>
   );

--- a/apps/web/components/providers.tsx
+++ b/apps/web/components/providers.tsx
@@ -1,22 +1,25 @@
 "use client";
 
 import * as React from "react";
+import { SessionProvider } from "next-auth/react";
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 import { TooltipProvider } from "@workspace/ui/components/tooltip";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <NextThemesProvider
-      attribute="class"
-      defaultTheme="system"
-      enableSystem
-      disableTransitionOnChange
-      enableColorScheme
-    >
-      <TooltipProvider>
-        <NuqsAdapter>{children}</NuqsAdapter>
-      </TooltipProvider>
-    </NextThemesProvider>
+    <SessionProvider>
+      <NextThemesProvider
+        attribute="class"
+        defaultTheme="system"
+        enableSystem
+        disableTransitionOnChange
+        enableColorScheme
+      >
+        <TooltipProvider>
+          <NuqsAdapter>{children}</NuqsAdapter>
+        </TooltipProvider>
+      </NextThemesProvider>
+    </SessionProvider>
   );
 }

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/auth";
 
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -8,7 +7,7 @@ export async function proxy(request: NextRequest) {
     return new NextResponse("Gone", { status: 410 });
   }
 
-  if (/^\/rankings\/a\/[^/]+\/(single|average)\/[^/]+$/i.test(pathname)) {
+  if (/^\/rankings\/a\/[^/]+\/(single|average)(\/[^/]+)?$/i.test(pathname)) {
     return new NextResponse("Gone", { status: 410 });
   }
 
@@ -20,5 +19,5 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!api/auth|_next/static|_next/image|favicon.ico).*)"],
+  matcher: ["/records/:path*", "/team/:path*", "/rankings/a/:path*"],
 };


### PR DESCRIPTION
Refactors heavy page data loading into on-demand flows: person profile tabs now fetch their data lazily via new server actions, with query-state tab/event syncing and loading skeletons. Competition “all results” now fetches and caches per-event data instead of loading every event at once, and footer data is cached with Next cache tags.

It also moves header auth/team lookup to a client-side `HeaderAuth` component backed by `SessionProvider`, removes `SpeedInsights`, and updates proxy matching to only run on targeted routes while expanding legacy rankings blocking.