### PR TITLE
fix: SR tagging and FMC average formatting

### DIFF
--- a/apps/backend/routes/admin_updates.py
+++ b/apps/backend/routes/admin_updates.py
@@ -1141,6 +1141,69 @@ def update_state_ranks():
         return jsonify({"success": False, "message": "Error updating state rankings"}), 500
 
 
+REGIONAL_RECORD_MARKERS = frozenset({"NR", "NAR", "WR"})
+
+
+def _to_date_key(start_date):
+    if hasattr(start_date, "isoformat"):
+        return start_date.isoformat()[:10]
+    return str(start_date)[:10]
+
+
+def _is_regional_record(marker):
+    return marker is not None and marker in REGIONAL_RECORD_MARKERS
+
+
+def _mark_state_records(rows, out_ids):
+    """Tag SR for chronological improvements.
+
+    Same competition start_date → only the best improvement that day is tagged.
+    Results that already have NR/NAR/WR are not tagged SR, but still advance best_so_far.
+    """
+    best_so_far = None
+    day_key = None
+    day_candidates = []
+
+    def flush_day():
+        nonlocal best_so_far, day_candidates
+
+        if not day_candidates:
+            return
+
+        improvements = [
+            row
+            for row in day_candidates
+            if best_so_far is None or row.value <= best_so_far
+        ]
+
+        if not improvements:
+            day_candidates = []
+            return
+
+        day_best = min(row.value for row in improvements)
+
+        for row in improvements:
+            if row.value == day_best and not _is_regional_record(row.regional_record):
+                out_ids.append(row.id)
+
+        best_so_far = day_best
+        day_candidates = []
+
+    for row in rows:
+        if row.value <= 0:
+            continue
+
+        key = _to_date_key(row.start_date)
+
+        if day_key is not None and key != day_key:
+            flush_day()
+
+        day_key = key
+        day_candidates.append(row)
+
+    flush_day()
+
+
 @admin_bp.route("/update-state-records", methods=["POST"])
 @require_cron_auth
 def update_state_records():
@@ -1188,7 +1251,10 @@ def update_state_records():
 
                         cur.execute(
                             """
-                            SELECT r.id, r.best AS value
+                            SELECT r.id,
+                                   r.best AS value,
+                                   c.start_date,
+                                   r.regional_single_record AS regional_record
                             FROM results r
                             INNER JOIN competitions c ON r.competition_id = c.id
                             LEFT JOIN round_types rt ON r.round_type_id = rt.id
@@ -1203,15 +1269,14 @@ def update_state_records():
                             """,
                             (event_id, person_ids),
                         )
-                        best_so_far = None
-                        for row in cur.fetchall():
-                            if best_so_far is None or row.value <= best_so_far:
-                                single_sr_ids.append(row.id)
-                                best_so_far = row.value
+                        _mark_state_records(cur.fetchall(), single_sr_ids)
 
                         cur.execute(
                             """
-                            SELECT r.id, r.average AS value
+                            SELECT r.id,
+                                   r.average AS value,
+                                   c.start_date,
+                                   r.regional_average_record AS regional_record
                             FROM results r
                             INNER JOIN competitions c ON r.competition_id = c.id
                             LEFT JOIN round_types rt ON r.round_type_id = rt.id
@@ -1226,11 +1291,7 @@ def update_state_records():
                             """,
                             (event_id, person_ids),
                         )
-                        best_so_far = None
-                        for row in cur.fetchall():
-                            if best_so_far is None or row.value <= best_so_far:
-                                average_sr_ids.append(row.id)
-                                best_so_far = row.value
+                        _mark_state_records(cur.fetchall(), average_sr_ids)
 
                 chunk_size = 500
                 for i in range(0, len(single_sr_ids), chunk_size):

--- a/apps/web/app/(root)/competitions/[id]/_lib/results.ts
+++ b/apps/web/app/(root)/competitions/[id]/_lib/results.ts
@@ -1,4 +1,4 @@
-import { formatTime, formatTime333mbf } from "@/lib/utils";
+import { formatAttemptValue } from "@/lib/utils";
 import type { CompetitionResultRow as BaseCompetitionResultRow } from "./queries";
 
 export type CompetitionResultRow = BaseCompetitionResultRow;
@@ -23,19 +23,12 @@ export interface ResultsByEventGroup {
 
 export function formatBestResult(resultRow: CompetitionResultRow): string {
   if (resultRow.best <= 0) return "—";
-
-  if (resultRow.eventId === "333fm") {
-    return `${resultRow.best}`;
-  }
-
-  if (resultRow.eventId === "333mbf") {
-    return formatTime333mbf(resultRow.best);
-  }
-
-  return formatTime(resultRow.best);
+  return formatAttemptValue(resultRow.eventId, resultRow.best) ?? "—";
 }
 
 export function formatAverageResult(resultRow: CompetitionResultRow): string {
   if (resultRow.average <= 0) return "—";
-  return formatTime(resultRow.average);
+  return (
+    formatAttemptValue(resultRow.eventId, resultRow.average, "average") ?? "—"
+  );
 }

--- a/apps/web/app/(root)/persons/[id]/_components/championship-podiums-tab.tsx
+++ b/apps/web/app/(root)/persons/[id]/_components/championship-podiums-tab.tsx
@@ -171,9 +171,11 @@ export function PersonChampionshipPodiumsTab({ podiums }: Props) {
                       {/* Average */}
                       <TableCell className="text-center font-semibold whitespace-nowrap">
                         {row.average > 0
-                          ? row.eventId === "333fm"
-                            ? row.average / 100
-                            : formatAttemptValue(row.eventId, row.average)
+                          ? formatAttemptValue(
+                              row.eventId,
+                              row.average,
+                              "average",
+                            )
                           : null}
                       </TableCell>
 

--- a/apps/web/app/(root)/persons/[id]/_components/records-tab.tsx
+++ b/apps/web/app/(root)/persons/[id]/_components/records-tab.tsx
@@ -168,9 +168,11 @@ export function PersonRecordsTab({ records }: Props) {
                       <TableCell className="whitespace-nowrap font-semibold">
                         {hasAverageRecord && (
                           <div className="flex items-center gap-1.5">
-                            {row.eventId === "333fm"
-                              ? row.average / 100
-                              : formatAttemptValue(row.eventId, row.average)}
+                            {formatAttemptValue(
+                              row.eventId,
+                              row.average,
+                              "average",
+                            )}
                             <RecordBadges
                               regional={row.regionalAverageRecord}
                               state={row.stateAverageRecord}

--- a/apps/web/app/(root)/persons/[id]/_components/results-tab.tsx
+++ b/apps/web/app/(root)/persons/[id]/_components/results-tab.tsx
@@ -187,13 +187,11 @@ export function PersonResultsTab({
                       >
                         {resultRow.average === 0
                           ? null
-                          : resultRow.eventId === "333fm" &&
-                              resultRow.average > 0
-                            ? resultRow.average / 100
-                            : formatAttemptValue(
-                                resultRow.eventId,
-                                resultRow.average,
-                              )}
+                          : formatAttemptValue(
+                              resultRow.eventId,
+                              resultRow.average,
+                              "average",
+                            )}
                       </TableCell>
                     )}
                     {Array.from({ length: solveCount }).map((_, index) => {

--- a/apps/web/app/(root)/persons/[id]/page.tsx
+++ b/apps/web/app/(root)/persons/[id]/page.tsx
@@ -11,6 +11,7 @@ import {
 import Image from "next/image";
 import { getEvents, getPerson } from "@/db/queries";
 import {
+  formatAttemptValue,
   formatTime,
   formatTime333mbf,
   getTier,
@@ -285,7 +286,11 @@ async function PersonPageContent({ id }: { id: string }) {
               </TableCell>
               <TableCell className="text-center font-semibold">
                 {record?.record?.average?.best
-                  ? formatTime(record?.record?.average?.best)
+                  ? formatAttemptValue(
+                      record.event,
+                      record.record.average.best,
+                      "average",
+                    )
                   : null}
               </TableCell>
               <TableCell

--- a/apps/web/app/(root)/rankings/[eventId]/[rankType]/_components/rankings-table-columns.tsx
+++ b/apps/web/app/(root)/rankings/[eventId]/[rankType]/_components/rankings-table-columns.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { type ColumnDef } from "@tanstack/react-table";
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
-import { formatTime, formatTime333mbf } from "@/lib/utils";
+import { formatAttemptValue, formatTime, formatTime333mbf } from "@/lib/utils";
 import { RankSingle } from "../_types";
 import { cn } from "@workspace/ui/lib/utils";
 import { usePathname } from "next/navigation";
@@ -81,9 +81,11 @@ export function getColumns({
         if (eventId === "333fm") {
           return (
             <div className="flex space-x-2">
-              {rankType === "single"
-                ? row.getValue("best")
-                : Number(row.getValue("best")) / 100}
+              {formatAttemptValue(
+                eventId,
+                Number(row.getValue("best")),
+                rankType === "average" ? "average" : "single",
+              )}
             </div>
           );
         }

--- a/apps/web/app/(root)/rankings/[eventId]/[rankType]/results/_components/rankings-table-columns.tsx
+++ b/apps/web/app/(root)/rankings/[eventId]/[rankType]/results/_components/rankings-table-columns.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { type ColumnDef } from "@tanstack/react-table";
 import { DataTableColumnHeader } from "@/components/data-table/data-table-column-header";
-import { formatTime, formatTime333mbf } from "@/lib/utils";
+import { formatAttemptValue, formatTime, formatTime333mbf } from "@/lib/utils";
 import { cn } from "@workspace/ui/lib/utils";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
@@ -212,7 +212,11 @@ export function getAverageColumns({
         if (eventId === "333fm") {
           return (
             <div className="flex space-x-2">
-              {Number(row.getValue("average")) / 100}
+              {formatAttemptValue(
+                eventId,
+                Number(row.getValue("average")),
+                "average",
+              )}
             </div>
           );
         }

--- a/apps/web/app/(root)/records/_components/current-records-views.tsx
+++ b/apps/web/app/(root)/records/_components/current-records-views.tsx
@@ -97,7 +97,11 @@ export function MixedRecordsTable({ records }: { records: CurrentRecord[] }) {
               {record.eventId === "333mbf" || !record.average ? (
                 <span className="text-muted-foreground font-thin">N/A</span>
               ) : (
-                formatRecordResult(record.eventId, record.average.best)
+                formatRecordResult(
+                  record.eventId,
+                  record.average.best,
+                  "average",
+                )
               )}
             </TableCell>
             <TableCell className="whitespace-nowrap">
@@ -201,7 +205,11 @@ export function SlimRecordsTables({ records }: { records: CurrentRecord[] }) {
                   </div>
                 </TableCell>
                 <TableCell>
-                  {formatRecordResult(record.eventId, record.average!.best)}
+                  {formatRecordResult(
+                    record.eventId,
+                    record.average!.best,
+                    "average",
+                  )}
                 </TableCell>
                 <TableCell className="whitespace-nowrap">
                   <PersonLink
@@ -292,7 +300,11 @@ export function SeparateRecordsTables({
                   </TableCell>
                   <TableCell>
                     {record.average ? (
-                      formatRecordResult(record.eventId, record.average.best)
+                      formatRecordResult(
+                        record.eventId,
+                        record.average.best,
+                        "average",
+                      )
                     ) : (
                       <span className="text-muted-foreground font-thin">
                         N/A

--- a/apps/web/app/(root)/records/_components/history-records-views.tsx
+++ b/apps/web/app/(root)/records/_components/history-records-views.tsx
@@ -74,7 +74,7 @@ function HistoryRow({
       </TableCell>
       <TableCell>
         {entry.isAverageRecord && entry.average > 0
-          ? formatRecordResult(entry.eventId, entry.average)
+          ? formatRecordResult(entry.eventId, entry.average, "average")
           : null}
       </TableCell>
       <TableCell className="whitespace-nowrap">{entry.personState}</TableCell>

--- a/apps/web/app/(root)/records/_components/show-selector.tsx
+++ b/apps/web/app/(root)/records/_components/show-selector.tsx
@@ -5,6 +5,13 @@ import {
   ToggleGroup,
   ToggleGroupItem,
 } from "@workspace/ui/components/toggle-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@workspace/ui/components/select";
 import { cn } from "@workspace/ui/lib/utils";
 import { parseAsStringEnum, useQueryStates } from "nuqs";
 import { SHOW_MODES, type ShowMode } from "../_lib/show-modes";
@@ -37,16 +44,31 @@ export function ShowSelector({ className, ...props }: ShowSelectorProps) {
   return (
     <div className={cn("flex flex-col gap-2", className)} {...props}>
       <span className="font-semibold text-sm">Mostrar</span>
+      <Select
+        value={selectedShow}
+        onValueChange={(value) => setQueryState({ show: value as ShowMode })}
+      >
+        <SelectTrigger className="w-full sm:hidden">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {SHOW_MODES.map((mode) => (
+            <SelectItem key={mode} value={mode}>
+              {SHOW_LABELS[mode]}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
       <ToggleGroup
         type="single"
         variant="outline"
         value={selectedShow}
-        className="w-full flex-wrap"
+        className="hidden w-full sm:flex"
       >
         {SHOW_MODES.map((mode) => (
           <ToggleGroupItem
             key={mode}
-            className="flex-1 min-w-fit"
+            className="flex-1 min-w-0"
             value={mode}
             aria-label={SHOW_LABELS[mode]}
             onClick={() => setQueryState({ show: mode })}

--- a/apps/web/app/(root)/records/_lib/format.ts
+++ b/apps/web/app/(root)/records/_lib/format.ts
@@ -1,11 +1,12 @@
-import { formatAttemptValue } from "@/lib/utils";
+import { formatAttemptValue, type ResultValueType } from "@/lib/utils";
 
 export function formatRecordResult(
   eventId: string,
   value: number | null | undefined,
+  resultType: ResultValueType = "single",
 ): string {
   if (value == null) return "N/A";
-  return formatAttemptValue(eventId, value) ?? "N/A";
+  return formatAttemptValue(eventId, value, resultType) ?? "N/A";
 }
 
 export function formatRecordSolves(

--- a/apps/web/app/(root)/summary/[year]/[wcaId]/_components/annual-summary-view.tsx
+++ b/apps/web/app/(root)/summary/[year]/[wcaId]/_components/annual-summary-view.tsx
@@ -30,18 +30,24 @@ function formatSummaryDate(iso: string): string {
   }).format(date);
 }
 
-function formatResultValue(eventId: string, value: number | null): string {
+function formatResultValue(
+  eventId: string,
+  value: number | null,
+  resultType: "single" | "average" = "single",
+): string {
   if (value === null) return "—";
-  return formatAttemptValue(eventId, value) ?? "—";
+  return formatAttemptValue(eventId, value, resultType) ?? "—";
 }
 
 function formatImprovement(
   eventId: string,
   improvement: number | null,
   improvementPercent: number | null,
+  resultType: "single" | "average" = "single",
 ): string {
   if (improvement === null || improvementPercent === null) return "—";
-  const abs = formatAttemptValue(eventId, improvement) ?? String(improvement);
+  const abs =
+    formatAttemptValue(eventId, improvement, resultType) ?? String(improvement);
   return `${abs} (${improvementPercent.toFixed(2)}%)`;
 }
 
@@ -511,16 +517,25 @@ export function AnnualSummaryView({ summary }: Props) {
                           <span className="ml-2">{row.eventName}</span>
                         </TableCell>
                         <TableCell className="text-center">
-                          {formatResultValue(row.eventId, row.before)}
+                          {formatResultValue(
+                            row.eventId,
+                            row.before,
+                            "average",
+                          )}
                         </TableCell>
                         <AccentCell>
-                          {formatResultValue(row.eventId, row.during)}
+                          {formatResultValue(
+                            row.eventId,
+                            row.during,
+                            "average",
+                          )}
                         </AccentCell>
                         <AccentCell>
                           {formatImprovement(
                             row.eventId,
                             row.improvement,
                             row.improvementPercent,
+                            "average",
                           )}
                         </AccentCell>
                       </TableRow>

--- a/apps/web/app/(root)/summary/[year]/[wcaId]/_components/summary-share-button.tsx
+++ b/apps/web/app/(root)/summary/[year]/[wcaId]/_components/summary-share-button.tsx
@@ -58,7 +58,7 @@ export function SummaryShareButton({ data }: Props) {
       const filename = `resumen-${data.year}-${data.wcaId}.png`;
       const file = new File([blob], filename, { type: "image/png" });
       const summaryUrl = `https://www.cubingmexico.net/summary/${data.year}/${data.wcaId}`;
-      const shareText = `Mi resumen anual ${data.year} en Cubing México\n${summaryUrl}`;
+      const shareText = `Mi resumen anual ${data.year} en Cubing México`;
 
       if (canShareFiles(file)) {
         try {

--- a/apps/web/lib/update-state-records.ts
+++ b/apps/web/lib/update-state-records.ts
@@ -11,6 +11,14 @@ import {
 import { EXCLUDED_EVENTS } from "@/lib/constants";
 
 const SR = "SR";
+const REGIONAL_RECORD_MARKERS = new Set(["NR", "NAR", "WR"]);
+
+type StateRecordRow = {
+  id: string;
+  value: number;
+  startDate: Date | string;
+  regionalRecord: string | null;
+};
 
 /** Clear historical SR tags for people leaving a state (or changing states). */
 export async function clearPersonStateRecords(personIds: string[]) {
@@ -30,6 +38,9 @@ export async function clearPersonStateRecords(personIds: string[]) {
 /**
  * Recompute historical state record markers for all current members of a state.
  * Attributes every past result to the person's current state_id (WCA-style running best).
+ *
+ * Same competition start_date → only the best improvement that day is tagged.
+ * Results that already have NR/NAR/WR are not tagged SR, but still advance bestSoFar.
  */
 export async function updateStateRecords(stateId: string) {
   const stateData = await db
@@ -74,6 +85,8 @@ export async function updateStateRecords(stateId: string) {
       .select({
         id: result.id,
         value: result.best,
+        startDate: competition.startDate,
+        regionalRecord: result.regionalSingleRecord,
       })
       .from(result)
       .innerJoin(competition, eq(result.competitionId, competition.id))
@@ -99,6 +112,8 @@ export async function updateStateRecords(stateId: string) {
       .select({
         id: result.id,
         value: result.average,
+        startDate: competition.startDate,
+        regionalRecord: result.regionalAverageRecord,
       })
       .from(result)
       .innerJoin(competition, eq(result.competitionId, competition.id))
@@ -146,18 +161,64 @@ export async function updateStateRecords(stateId: string) {
   };
 }
 
-function markStateRecords(
-  rows: { id: string; value: number }[],
-  outIds: string[],
-) {
+function toDateKey(startDate: Date | string): string {
+  if (startDate instanceof Date) {
+    return startDate.toISOString().slice(0, 10);
+  }
+  return String(startDate).slice(0, 10);
+}
+
+function isRegionalRecord(marker: string | null): boolean {
+  return marker !== null && REGIONAL_RECORD_MARKERS.has(marker);
+}
+
+/**
+ * Tag SR for chronological improvements, collapsing to the best value per
+ * competition start_date and skipping results that already hold NR/NAR/WR.
+ */
+function markStateRecords(rows: StateRecordRow[], outIds: string[]) {
   let bestSoFar: number | null = null;
+  let dayKey: string | null = null;
+  let dayCandidates: StateRecordRow[] = [];
+
+  const flushDay = () => {
+    if (dayCandidates.length === 0) {
+      return;
+    }
+
+    const improvements = dayCandidates.filter(
+      (row) => bestSoFar === null || row.value <= bestSoFar,
+    );
+
+    if (improvements.length === 0) {
+      dayCandidates = [];
+      return;
+    }
+
+    const dayBest = Math.min(...improvements.map((row) => row.value));
+
+    for (const row of improvements) {
+      if (row.value === dayBest && !isRegionalRecord(row.regionalRecord)) {
+        outIds.push(row.id);
+      }
+    }
+
+    bestSoFar = dayBest;
+    dayCandidates = [];
+  };
 
   for (const row of rows) {
     if (row.value <= 0) continue;
 
-    if (bestSoFar === null || row.value <= bestSoFar) {
-      outIds.push(row.id);
-      bestSoFar = row.value;
+    const key = toDateKey(row.startDate);
+
+    if (dayKey !== null && key !== dayKey) {
+      flushDay();
     }
+
+    dayKey = key;
+    dayCandidates.push(row);
   }
+
+  flushDay();
 }

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -194,9 +194,12 @@ export function roundTypeLabel(id?: string | null) {
   }
 }
 
+export type ResultValueType = "single" | "average";
+
 export function formatAttemptValue(
   eventId: string,
   value: number,
+  resultType: ResultValueType = "single",
 ): string | null {
   if (value === 0) {
     return null;
@@ -209,6 +212,10 @@ export function formatAttemptValue(
   if (eventId === "333fm") {
     if (value === -1) return "DNF";
     if (value === -2) return "DNS";
+    // WCA stores FMC means as moves × 100 (e.g. 2450 → 24.50)
+    if (resultType === "average") {
+      return (value / 100).toFixed(2);
+    }
     return `${value}`;
   }
 


### PR DESCRIPTION
Updates state-record recomputation in both backend and web to tag SRs by chronological day-level improvements, keep best-so-far progression, and avoid adding SR when a result already has NR/NAR/WR. It also extends `formatAttemptValue` with an explicit result type so 333fm averages are formatted correctly (moves/100) across competition, person, rankings, records, and annual summary views. Additionally, the summary share text no longer appends the URL directly.